### PR TITLE
Fixed `endpoint_url` field in `compute`

### DIFF
--- a/cloud_info/providers/openstack.py
+++ b/cloud_info/providers/openstack.py
@@ -97,7 +97,7 @@ class OpenStackProvider(providers.BaseProvider):
                 e_url = ept['publicURL']
 
                 e = defaults.copy()
-                e.update({'endpoint_url': e_url,
+                e.update({'compute_endpoint_url': e_url,
                           'compute_api_type': e_type,
                           'compute_api_version': e_version})
 

--- a/cloud_info/providers/static.py
+++ b/cloud_info/providers/static.py
@@ -138,7 +138,8 @@ class StaticProvider(providers.BaseProvider):
                          'middleware_developer',
                          'service_name')
         endpoint_fields = ('production_level', 'api_type', 'api_version',
-                           'api_endpoint_technology', 'api_authn_method')
+                           'api_endpoint_technology', 'api_authn_method',
+                           'endpoint_url')
         endpoints = self._get_what('compute',
                                    'endpoints',
                                    global_fields,

--- a/cloud_info/tests/data.py
+++ b/cloud_info/tests/data.py
@@ -75,6 +75,8 @@ class Data(object):
             'compute_service_name': socket.getfqdn(),
             'endpoints': {
                 'https://cloud-service01.example.org:8787': {
+                    'compute_endpoint_url':
+                        'https://cloud-service01.example.org:8787',
                     'compute_api_authn_method': 'X509-VOMS',
                     'compute_api_endpoint_technology': 'REST',
                     'compute_api_type': 'OCCI',
@@ -82,6 +84,8 @@ class Data(object):
                     'compute_production_level': 'unknown',
                 },
                 'https://cloud-service02.example.org:8787': {
+                    'compute_endpoint_url':
+                        'https://cloud-service02.example.org:8787',
                     'compute_api_authn_method': 'X509',
                     'compute_api_endpoint_technology': 'REST',
                     'compute_api_type': 'OCCI',
@@ -89,6 +93,8 @@ class Data(object):
                     'compute_production_level': 'testing',
                 },
                 'https://cloud-service03.example.org:8787': {
+                    'compute_endpoint_url':
+                        'https://cloud-service03.example.org:8787',
                     'compute_api_authn_method': 'User/Password',
                     'compute_api_endpoint_technology': 'REST',
                     'compute_api_type': 'OCCI',

--- a/cloud_info/tests/test_openstack.py
+++ b/cloud_info/tests/test_openstack.py
@@ -315,7 +315,8 @@ class OpenStackProviderTest(unittest.TestCase):
                 '1b7f14c87d8c42ad962f4d3a5fd13a77': {
                     'compute_api_type': 'OpenStack',
                     'compute_api_version': '99.99',
-                    'compute_endpoint_url': 'https://cloud.example.org:8774/v1.1/ce2d'}
+                    'compute_endpoint_url':
+                        'https://cloud.example.org:8774/v1.1/ce2d'}
             },
             'compute_middleware_developer': 'OpenStack',
             'compute_middleware': 'OpenStack Nova',
@@ -346,7 +347,8 @@ class OpenStackProviderTest(unittest.TestCase):
                 '1b7f14c87d8c42ad962f4d3a5fd13a77': {
                     'compute_api_type': 'OpenStack',
                     'compute_api_version': '2',
-                    'compute_endpoint_url': 'https://cloud.example.org:8774/v1.1/ce2d'}
+                    'compute_endpoint_url':
+                        'https://cloud.example.org:8774/v1.1/ce2d'}
             },
             'compute_middleware_developer': 'OpenStack',
             'compute_middleware': 'OpenStack Nova',

--- a/cloud_info/tests/test_openstack.py
+++ b/cloud_info/tests/test_openstack.py
@@ -311,11 +311,11 @@ class OpenStackProviderTest(unittest.TestCase):
                 '03e087c8fb3b495c9a360bcba3abf914': {
                     'compute_api_type': 'OCCI',
                     'compute_api_version': '11.11',
-                    'endpoint_url': 'https://cloud.example.org:8787/'},
+                    'compute_endpoint_url': 'https://cloud.example.org:8787/'},
                 '1b7f14c87d8c42ad962f4d3a5fd13a77': {
                     'compute_api_type': 'OpenStack',
                     'compute_api_version': '99.99',
-                    'endpoint_url': 'https://cloud.example.org:8774/v1.1/ce2d'}
+                    'compute_endpoint_url': 'https://cloud.example.org:8774/v1.1/ce2d'}
             },
             'compute_middleware_developer': 'OpenStack',
             'compute_middleware': 'OpenStack Nova',
@@ -342,11 +342,11 @@ class OpenStackProviderTest(unittest.TestCase):
                 '03e087c8fb3b495c9a360bcba3abf914': {
                     'compute_api_type': 'OCCI',
                     'compute_api_version': '1.1',
-                    'endpoint_url': 'https://cloud.example.org:8787/'},
+                    'compute_endpoint_url': 'https://cloud.example.org:8787/'},
                 '1b7f14c87d8c42ad962f4d3a5fd13a77': {
                     'compute_api_type': 'OpenStack',
                     'compute_api_version': '2',
-                    'endpoint_url': 'https://cloud.example.org:8774/v1.1/ce2d'}
+                    'compute_endpoint_url': 'https://cloud.example.org:8774/v1.1/ce2d'}
             },
             'compute_middleware_developer': 'OpenStack',
             'compute_middleware': 'OpenStack Nova',

--- a/etc/sample.static.yaml
+++ b/etc/sample.static.yaml
@@ -59,12 +59,15 @@ compute:
             production_level: unknown
 
         https://cloud-service01.example.org:8787:
+            endpoint_url: https://cloud-service01.example.org:8787
 
         https://cloud-service02.example.org:8787:
+            endpoint_url: https://cloud-service02.example.org:8787
             api_authn_method: X509
             production_level: testing
 
         https://cloud-service03.example.org:8787:
+            endpoint_url: https://cloud-service03.example.org:8787
             api_authn_method: User/Password
 
     templates:
@@ -79,11 +82,11 @@ compute:
         resource_tpl#medium:
             memory: 4096
             cpu: 2
-        
+
         resource_tpl#large:
             memory: 8196
             cpu: 4
-        
+
         resource_tpl#extra_large:
             memory: 16384
             cpu: 8

--- a/etc/templates/compute.ldif
+++ b/etc/templates/compute.ldif
@@ -28,17 +28,17 @@ GLUE2ComputingManagerTotalLogicalCPUs: ${static_compute_info['compute_total_core
 GLUE2ComputingManagerWorkingAreaTotal: ${static_compute_info['compute_total_ram']}
 
 % for url, endpoint in endpoints['endpoints'].items():
-dn: GLUE2EndpointID=${endpoint['endpoint_url']}_${endpoint['compute_api_type']}_${endpoint['compute_api_version']}_${endpoint['compute_api_authn_method']},GLUE2ServiceID=${endpoint['compute_service_name']}_cloud.compute,GLUE2GroupID=cloud,${endpoint['suffix']}
+dn: GLUE2EndpointID=${endpoint['compute_endpoint_url']}_${endpoint['compute_api_type']}_${endpoint['compute_api_version']}_${endpoint['compute_api_authn_method']},GLUE2ServiceID=${endpoint['compute_service_name']}_cloud.compute,GLUE2GroupID=cloud,${endpoint['suffix']}
 objectClass: GLUE2Entity
 objectClass: GLUE2Endpoint
 objectClass: GLUE2ComputingEndpoint
 GLUE2EndpointHealthState: ok
-GLUE2EndpointID: ${endpoint['endpoint_url']}_${endpoint['compute_api_type']}_${endpoint['compute_api_version']}_${endpoint['compute_api_authn_method']}
+GLUE2EndpointID: ${endpoint['compute_endpoint_url']}_${endpoint['compute_api_type']}_${endpoint['compute_api_version']}_${endpoint['compute_api_authn_method']}
 GLUE2EndpointInterfaceName: ${endpoint['compute_api_type']}
 GLUE2EndpointQualityLevel: ${endpoint['compute_production_level']}
 GLUE2EndpointServiceForeignKey: ${endpoint['compute_service_name']}_cloud.compute
 GLUE2EndpointServingState: ${endpoint['compute_production_level']}
-GLUE2EndpointURL: ${endpoint['endpoint_url']}
+GLUE2EndpointURL: ${endpoint['compute_endpoint_url']}
 GLUE2ComputingEndpointComputingServiceForeignKey: ${endpoint['compute_service_name']}_cloud.compute
 GLUE2EndpointCapability: ${endpoint['compute_capabilities']}
 GLUE2EndpointImplementationName: ${endpoint['compute_middleware']}


### PR DESCRIPTION
I'm not sure if this is the right approach. Please, comment.

When updating ONe provider, I noticed that `compute.ldif` expects a field set only by the OpenStack provider and it fails for every other provider. This field was not namespaced (== prefixed) or treated as an endpoint field by the static provider.

The proposed change will require a version bump (slight changes in configuration files) but should work consistently across all providers. It mandates `endpoint_url` as an explicit field for `compute` endpoints.