### PR TITLE
Document package building and fix build on Xenial

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,7 @@ Build-Depends:
  debhelper (>= 7.0.50),
  dh-python,
  python-all (>= 2.7),
- python-all-dev (>= 2.7),
- python-support
+ python-all-dev (>= 2.7)
 Build-Depends-Indep:
  python-pbr (>= 0.6),
  python-setuptools


### PR DESCRIPTION
Document RPM and deb package building using containers.

python-support packages was removed from the repositories and in fact dh-python build dependency is sufficient.