### PR TITLE
Optionally use the version entry from vmcatcher as image_version.

### DIFF
--- a/cloud_info/providers/openstack.py
+++ b/cloud_info/providers/openstack.py
@@ -203,7 +203,8 @@ class OpenStackProvider(providers.BaseProvider):
                 aux_img['image_os_version'] = distro_version
             if image.metadata.get('image_version', None) is not None:
                 image_version = image.metadata['image_version']
-            elif image.metadata.get('vmcatcher_event_hv_version', None) is not None:
+            elif image.metadata.get('vmcatcher_event_hv_version', None) \
+                    is not None:
                 image_version = image.metadata['vmcatcher_event_hv_version']
             else:
                 if (image.metadata.get('distro', None) is not None) and (

--- a/cloud_info/providers/openstack.py
+++ b/cloud_info/providers/openstack.py
@@ -203,6 +203,8 @@ class OpenStackProvider(providers.BaseProvider):
                 aux_img['image_os_version'] = distro_version
             if image.metadata.get('image_version', None) is not None:
                 image_version = image.metadata['image_version']
+            elif image.metadata.get('vmcatcher_event_hv_version', None) is not None:
+                image_version = image.metadata['vmcatcher_event_hv_version']
             else:
                 if (image.metadata.get('distro', None) is not None) and (
                         image.metadata.get(distro_version) is not None):


### PR DESCRIPTION
This small patch adds the vmcatcher way of storing the image version in case the image_version metadata entry is not set.