### PR TITLE
Fixed deep hash lookup for ONe provider

### DIFF
--- a/cloud_info/providers/opennebula.py
+++ b/cloud_info/providers/opennebula.py
@@ -156,7 +156,7 @@ class OpenNebulaBaseProvider(providers.BaseProvider):
         for key in keys:
             if tc is None:
                 return None
-            tc = tc[key]
+            tc = tc.get(key)
         return tc
 
 


### PR DESCRIPTION
Ref. https://ggus.eu/index.php?mode=ticket_info&ticket_id=129289

Using `[]` on a dictionary for a non-existent key will raise
an error. Using `.get()` is more appropriate here.