### PR TITLE
Fixing entry updates for ApplicationEnvironment

### DIFF
--- a/etc/templates/compute.ldif
+++ b/etc/templates/compute.ldif
@@ -89,6 +89,7 @@ GLUE2EntityOtherInfo: disk=${template['template_disk']}
 dn: GLUE2ApplicationEnvironmentID=${image['image_id']}_${endpoint['compute_service_name']},GLUE2ServiceID=${endpoint['compute_service_name']}_cloud.compute,GLUE2GroupID=cloud,${endpoint['suffix']}
 objectClass: GLUE2Entity
 objectClass: GLUE2ApplicationEnvironment
+GLUE2ApplicationEnvironmentID: ${image['image_id']}_${endpoint['compute_service_name']}
 GLUE2ApplicationEnvironmentAppName: ${image['image_name']}
 GLUE2ApplicationEnvironmentAppVersion: ${image['image_version']}
 GLUE2ApplicationEnvironmentRepository: ${image['image_marketplace_id']}


### PR DESCRIPTION
Missing attribute was causing the following errors and breaking entry updates (at least on CentOS 7):
```
2017-11-09 15:22:18,808: [WARNING] ldap_modify: Naming violation (64)
2017-11-09 15:22:18,808: [WARNING] additional info: naming attribute 'GLUE2ApplicationEnvironmentID' is not present in entry
```