### PR TITLE
Prepare version 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The generated representation is described using a
 [Mako](http://www.makotemplates.org/) template having access to the cloud
 middleware information.
 
+Supported cloud middleware providers:
+* OpenNebula
+* OpenStack using Keystone authentication with API v3 *only*
+
 ## Installation
 
 ### Dependencies
@@ -27,6 +31,19 @@ probably need:
 
 On RHEL you will also need to enable the [EPEL repository](http://fedoraproject.org/wiki/EPEL) for python-defusedxml
 that is required for the OpenNebula provider.
+
+For the time being the pacakge is the same for all the providers, so
+provider-specific dependencies needs to be installed manually.
+
+#### OpenStack provider dependencies
+
+* python-novaclient
+* python-glanceclient
+* python-keystoneauth1
+
+#### OpenNebula provider dependencies
+
+* python-defusedxml
 
 ### Binary packages
 
@@ -160,8 +177,9 @@ listing of options.
 For example for OpenStack, use a command line similar to the following:
 ```sh
 cloud-info-provider-service --yaml-file /etc/cloud-info-provider/static.yaml \
-    --middleware OpenStack --os-username <username> --os-password <password> \
-    --os-tenant-name <tenant> --os-auth-url <auth-url>
+    --middleware openstack --os-username <username> --os-password <password> \
+    --os-user-domain-name default --os-project-name <tenant> \
+    --os-project-domain-name default --os-auth-url <auth-url>
 ```
 
 **Test the generation of the LDIF before running the provider into your BDII!**
@@ -191,9 +209,9 @@ calls the provider with the correct options for your site:
 
 cloud-info-provider-service --yaml /etc/cloud-info-provider/openstack.yaml \
                             --middleware openstack \
-                            --os-username <username> --os-password <passwd> \
-                            --os-tenant-name <tenant> --os-auth-url <url>
-
+                            --os-username <username> --os-password <password> \
+                            --os-user-domain-name default --os-project-name <tenant> \
+                            --os-project-domain-name default --os-auth-url <auth-url>
 ```
 
 Give execution permission:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+python-cloud-info-provider (0.9.0-1) xenial; urgency=medium
+
+  [ Alvaro Lopez ]
+  * Use keystoneauth and v3 API (OS provider)
+  * OpenStack Identity API v2.0 isn't supported anymore
+
+  [ Boris Parak ]
+  * Fix entry updates for ApplicationEnvironment
+
+  [ Baptiste Grenier ]
+  * Updated package building and documentation
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu>  Fri, 30 Mar 2018 17:51:03 +0200
+
 python-cloud-info-provider (0.8.4-1) xenial; urgency=medium
 
   [ Boris Parak ]

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${python:Depends}, ${misc:Depends},
  python-mako,
  python-six
 #Recommends: bdii
-Suggests: python-novaclient, python-defusedxml
+Suggests: python-novaclient, python-defusedxml, python-glanceclient, python-keystoneauth1
 Provides: ${python:Provides}
 Description: Cloud information provider for BDII.
  Information provider for Cloud Compute and Cloud Storage services.

--- a/rpm/cloud-info-provider.spec
+++ b/rpm/cloud-info-provider.spec
@@ -59,7 +59,7 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Fri Mar 30 2018 Baptiste Grenier <baptiste.grenier@egi.eu> 0.9.0
 - Use keystoneauth and v3 API, deprecate v2.0 API (Alvaro Lopez)
-- Fix Fix entry updates for ApplicationEnvironment (Boris Parak)
+- Fix entry updates for ApplicationEnvironment (Boris Parak)
 - Update package building and documentation (Baptiste Grenier)
 * Tue Oct 03 2017 Baptiste Grenier <baptiste.grenier@egi.eu> 0.8.4
 - Add support for rOCCI-server v2 (Boris Parak)

--- a/rpm/cloud-info-provider.spec
+++ b/rpm/cloud-info-provider.spec
@@ -6,7 +6,7 @@
 
 Summary: Information provider for Cloud Compute and Cloud Storage services for BDII
 Name: cloud-info-provider
-Version: 0.8.4
+Version: 0.9.0
 Release: 1%{?dist}
 Group: Applications/Internet
 License: ASL 2.0
@@ -26,6 +26,8 @@ Requires: python-six
 #Requires: python-defusedxml
 # For OpenStack
 #Requires: python-novaclient
+#Requires: python-glanceclient
+#Requires: python-keystoneauth1
 Obsoletes: cloud-info-provider-service
 BuildArch: noarch
 
@@ -55,6 +57,10 @@ rm -rf $RPM_BUILD_ROOT
 %config /etc/cloud-info-provider/
 
 %changelog
+* Fri Mar 30 2018 Baptiste Grenier <baptiste.grenier@egi.eu> 0.9.0
+- Use keystoneauth and v3 API, deprecate v2.0 API (Alvaro Lopez)
+- Fix Fix entry updates for ApplicationEnvironment (Boris Parak)
+- Update package building and documentation (Baptiste Grenier)
 * Tue Oct 03 2017 Baptiste Grenier <baptiste.grenier@egi.eu> 0.8.4
 - Add support for rOCCI-server v2 (Boris Parak)
 * Tue Jul 04 2017 Baptiste Grenier <baptiste.grenier@egi.eu> 0.8.3


### PR DESCRIPTION
- Use keystoneauth and v3 API, deprecate v2.0 API (Alvaro Lopez)
  - OpenStack Identity API v2.0 has been deprecated and is *no more supported*
- Fix Fix entry updates for ApplicationEnvironment (Boris Parak)
- Update package building and documentation (Baptiste Grenier)